### PR TITLE
Update colorize functionality to add support for Ruby 3.0.0

### DIFF
--- a/lib/rbcat.rb
+++ b/lib/rbcat.rb
@@ -7,6 +7,6 @@ require "rbcat/cli"
 
 module Rbcat
   def self.colorize(string, options = {})
-    Colorizer.colorize(string, options)
+    Colorizer.colorize(string, **options)
   end
 end

--- a/lib/rbcat/version.rb
+++ b/lib/rbcat/version.rb
@@ -1,3 +1,3 @@
 module Rbcat
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Currently the gem is not usable for Ruby 3.0.0 due to the separation of positional and keyword arguments, this change will update the functionality, allowing us to use the gem with Ruby 3.0.0.

This change has been tested locally and works as expected using Ruby 3.0.0.

For more information, see: [Separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

This addresses issue https://github.com/vifreefly/rbcat/issues/1 raised by @graial